### PR TITLE
Lower TDP on AC to 70W

### DIFF
--- a/lib/systemd/system-sleep/amd-ppt
+++ b/lib/systemd/system-sleep/amd-ppt
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+set -e
+
+match="0"
+case "$(cat /sys/class/dmi/id/sys_vendor)" in
+    System76)
+		case "$(cat /sys/class/dmi/id/product_version)" in
+			serw12)
+				match="1"
+				;;
+		esac
+		;;
+esac
+
+if [ "$match" != "1" ]
+then
+	exit 0
+fi
+
+case "$2" in
+	suspend | hybrid-sleep)
+		case "$1" in
+			post)
+				udevadm trigger /sys/class/power_supply/AC
+				;;
+		esac
+		;;
+esac

--- a/lib/udev/rules.d/80-amd-ppt.rules
+++ b/lib/udev/rules.d/80-amd-ppt.rules
@@ -2,7 +2,7 @@ ATTR{[dmi/id]sys_vendor}=="System76", ATTR{[dmi/id]product_version}=="serw12", G
 GOTO="amd-ppt_none"
 
 LABEL="amd-ppt_serw12"
-SUBSYSTEM=="power_supply", KERNEL=="AC", ENV{POWER_SUPPLY_ONLINE}=="1", RUN+="/usr/bin/amd-ppt 88000"
+SUBSYSTEM=="power_supply", KERNEL=="AC", ENV{POWER_SUPPLY_ONLINE}=="1", RUN+="/usr/bin/amd-ppt 70000"
 SUBSYSTEM=="power_supply", KERNEL=="AC", ENV{POWER_SUPPLY_ONLINE}=="0", RUN+="/usr/bin/amd-ppt 28000"
 
 LABEL="amd-ppt_none"


### PR DESCRIPTION
This may fix overdraw issues when on AC power, and reduce the chance of overheating. I will thoroughly test with the Ryzen 9 3900 and RTX 2070 tomorrow.